### PR TITLE
Set up logging explicitly

### DIFF
--- a/kinto_fxa/scripts/__main__.py
+++ b/kinto_fxa/scripts/__main__.py
@@ -3,7 +3,7 @@ Main entry point for kinto_fxa scripts.
 """
 
 import argparse
-import logging
+import logging.config
 import os
 
 from pyramid.paster import bootstrap
@@ -33,6 +33,7 @@ def main(args=None):
 
     opts = parser.parse_args(args)
 
+    logging.config.fileConfig(opts.ini_file, disable_existing_loggers=False)
     logger.debug("Using config file %r", opts.ini_file)
     config = bootstrap(opts.ini_file)
 

--- a/kinto_fxa/tests/test_scripts_main.py
+++ b/kinto_fxa/tests/test_scripts_main.py
@@ -28,4 +28,5 @@ class TestScripts(unittest.TestCase):
         self.process_account_events.assert_called_with(
             self.config, 'my-queue-name', None, 20
         )
-        self.fileConfig.assert_called_with(main.DEFAULT_CONFIG_FILE, disable_existing_loggers=False)
+        self.fileConfig.assert_called_with(main.DEFAULT_CONFIG_FILE,
+                                           disable_existing_loggers=False)

--- a/kinto_fxa/tests/test_scripts_main.py
+++ b/kinto_fxa/tests/test_scripts_main.py
@@ -15,6 +15,10 @@ class TestScripts(unittest.TestCase):
         self.bootstrap = bootstrap_patcher.start()
         self.addCleanup(bootstrap_patcher.stop)
 
+        logging_patcher = mock.patch('logging.config.fileConfig')
+        self.fileConfig = logging_patcher.start()
+        self.addCleanup(logging_patcher.stop)
+
         self.config = mock.Mock()
         self.bootstrap.return_value = self.config
 
@@ -24,3 +28,4 @@ class TestScripts(unittest.TestCase):
         self.process_account_events.assert_called_with(
             self.config, 'my-queue-name', None, 20
         )
+        self.fileConfig.assert_called_with(main.DEFAULT_CONFIG_FILE, disable_existing_loggers=False)


### PR DESCRIPTION
I don't use paster.setup_logging because of
https://github.com/Pylons/pyramid/issues/2975, which disables any
loggers that were already defined. Since most are defined at import
time, almost every logger is already set up.