### PR TITLE
Get rid of extra kinto requirement

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-kinto
 coverage
 mock
 nose


### PR DESCRIPTION
This is already in requirements.txt, so we don't really need it here.